### PR TITLE
Add fallback link for Facebook iframe and update demo preview

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -5,55 +5,59 @@ search: false
 
 @charset "utf-8";
 
-@import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}"; // skin
-@import "minimal-mistakes"; // main partials
+@import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}";
+@import "minimal-mistakes";
 
 @font-face {
-    font-family: 'Literata-Bold';
-    src: url('../fonts/Literata-Bold.woff2') format('woff2'),
-            url('../fonts/Literata-Bold.woff') format('woff'),
-            url('../fonts/Literata-Bold.ttf') format('truetype');
-    font-weight: 700;
-    font-display: swap;
-    font-style: normal;
+  font-family: "Literata-Bold";
+  src: url("../fonts/Literata-Bold.woff2") format("woff2"),
+       url("../fonts/Literata-Bold.woff") format("woff"),
+       url("../fonts/Literata-Bold.ttf") format("truetype");
+  font-weight: 700;
+  font-display: swap;
+  font-style: normal;
 }
 
 h1 {
-  padding-top: 10pt; /* Adjust the value as needed */
+  padding-top: 10pt;
 }
 
 .site-title {
-    font-family: 'Literata-Bold', serif;    
-    vertical-align: bottom;
-    font-weight: bold;
-    margin: 0.2rem 0 0 0.2rem;
-    font-size: 1.5rem;    
+  font-family: "Literata-Bold", serif;
+  vertical-align: bottom;
+  font-weight: bold;
+  margin: 0.2rem 0 0 0.2rem;
+  font-size: 1.5rem;
 }
 
 .site-subtitle {
-    font-family: 'Literata-Bold', serif; 
-    margin: 0.2rem 0 0 0.2rem;
-    font-weight: bold;
-    font-size: 1rem;    
+  font-family: "Literata-Bold", serif;
+  margin: 0.2rem 0 0 0.2rem;
+  font-weight: bold;
+  font-size: 1rem;
 }
 
 .site-logo img {
-    padding-top: 0.1rem;
-    max-height: 2.7rem;
-  }
+  padding-top: 0.1rem;
+  max-height: 2.7rem;
+}
 
-  .flex-container {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-  }
+.homepage-section--facebook {
+  margin-top: 1rem;
+}
 
-  .flex-element-news {
-    flex: 30%
-  }
+.facebook-embed-wrapper {
+  display: flex;
+  justify-content: center;
+}
 
-  @media (max-width: 660px) {
-    .flex-element-news {
-        flex: 100%
-    }
-  }
+.facebook-embed-wrapper iframe {
+  width: min(100%, 500px);
+}
+
+
+.facebook-embed-note {
+  margin-top: 0.75rem;
+  text-align: center;
+  font-size: 0.95rem;
+}

--- a/demo-preview.html
+++ b/demo-preview.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="cs">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Knihkupka – demo náhledu</title>
+  <style>
+    body { font-family: Georgia, serif; margin: 0; background: #fafafa; color: #222; }
+    header { padding: 18px 24px; border-bottom: 1px solid #ddd; background: #fff; }
+    .brand { font-size: 1.6rem; font-weight: 700; }
+    .subtitle { color: #666; margin-top: 4px; }
+    main { max-width: 980px; margin: 24px auto; padding: 0 16px; }
+    h2 { margin-bottom: 14px; }
+    .facebook-embed-wrapper { display: flex; justify-content: center; }
+    iframe { width: min(100%, 500px); border: none; overflow: hidden; min-height: 720px; background: #fff; }
+    .note { margin-top: 16px; color: #666; font-size: .92rem; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="brand">knihkupka</div>
+    <div class="subtitle">knihkupectví v Novém Strašecí</div>
+  </header>
+  <main>
+    <h2>Novinky</h2>
+    <div class="facebook-embed-wrapper">
+      <iframe
+        title="Facebook stránka Knihkupka"
+        src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Fknihkupka&tabs=timeline&width=500&height=720&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=false&appId"
+        width="500"
+        height="720"
+        scrolling="no"
+        frameborder="0"
+        allowfullscreen="true"
+        allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share">
+      </iframe>
+    </div>
+    <p class="note">Pokud se náhled nezobrazuje, otevřete naši stránku přímo na <a href="https://www.facebook.com/knihkupka" target="_blank" rel="noopener">Facebooku</a>.</p>
+    <p class="note">Demo-only preview stránka pro vizuální ověření Facebook iframe sekce bez Jekyll buildu.</p>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -6,57 +6,25 @@ description: "Máme hodně knih pro děti, nějakou tu beletrii i trochu toho od
 excerpt: "Malé knihkupectví v malém městě, ale něco se do něj vejde."
 header:
   overlay_image: /assets/images/background-home.jpg
-  overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background 
+  overlay_filter: 0.5
 ---
 
-<h2>Novinky</h2>
-<div id="facebook-feed"></div>
+<section class="homepage-section homepage-section--facebook">
+  <h2>Novinky</h2>
 
-<script>
-  const access_token = "EAAFBdh8d7kABO9JFSYHiZAoB50fzxnrBPREDbuFBy1tdHugoHSNZB50hpu0ZA435XFxHzZB8Fg6raSZAVk39zUU8MKjZBWh4lybbuegBKLkSlwYbMH9yMwFqZBxEkISWjf20xNapJ73iniPOcNWuqHvLknD8DVRGy4PlXGRKIC0ECURfyYZBDxPDFuPHMlrMv2EZD";
-  fetch(`https://graph.facebook.com/v20.0/114349938298748/posts?limit=100&fields=id,message,permalink_url,created_time,attachments&access_token=${access_token}`, {
-    method: "GET",
-    credentials: "same-origin"
-  }).then(response => response.json())
-    .then(response => {
-       var posts = response.data;
-       var feedHtml = '<div class="flex-container">';
-       var i=0;
-       posts
-       .filter(post => post.message || post.attachments)
-       .slice(0, 6)
-       .forEach(function(post) {
-         feedHtml += `
-           <div class="flex-element-news" style="padding:0.5em; display:flex; flex-direction:column; justify-content:space-between; ${i++ % 2 == 0 ? 'background-color: #f0f0f0;"' : ''}">
-            <div><em>${new Date(post.created_time).toLocaleDateString()}</em> ${post.message?'<p>' + post.message + '</p>' : ''}
-            <div id="${post.id}" style="display: flex; flex-direction: row; flex-wrap: wrap; justify-content: center; align-items: center;"></div></div>
-            <div><a href="${post.permalink_url}">Zobrazit na Facebooku</a></div>
-           </div>`;
+  <div class="facebook-embed-wrapper">
+    <iframe
+      title="Facebook stránka Knihkupka"
+      src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Fknihkupka&tabs=timeline&width=500&height=720&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=false&appId"
+      width="500"
+      height="720"
+      style="border:none;overflow:hidden"
+      scrolling="no"
+      frameborder="0"
+      allowfullscreen="true"
+      allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share">
+    </iframe>
+  </div>
 
-          fetch(`https://graph.facebook.com/v20.0/${post.id}/attachments?access_token=${access_token}`, {
-            method: "GET",
-            credentials: "same-origin"
-         }).then(response => response.json())
-           .then(response => {
-              if (response.data.length > 0) {
-                var attachment = response.data[0];
-                var media = attachment.media;
-                if (media && media.image) {
-                  var image = media.image;
-                  var imageUrl = image.src;
-                  var imageElement = document.createElement("img");
-                  imageElement.style.alignSelf = "center";
-                  imageElement.style.width = "300px";
-                  imageElement.src = imageUrl;
-                  imageElement.alt = "Příloha k příspěvku";
-                  document.getElementById(post.id).appendChild(imageElement);
-                }
-              }
-           });
-       });
-       feedHtml += '</div>';
-       document.getElementById('facebook-feed').innerHTML = feedHtml;
-    }
- );
-
-</script>
+  <p class="facebook-embed-note">Pokud se náhled nezobrazuje, otevřete naši stránku přímo na <a href="https://www.facebook.com/knihkupka" target="_blank" rel="noopener">Facebooku</a>.</p>
+</section>


### PR DESCRIPTION
### Motivation
- Embedded Facebook timeline can be blocked or appear blank in some environments, making the homepage section look broken in demos and previews.
- Provide a usable, minimal preview that works without a full Jekyll build so the Facebook section can be visually validated.

### Description
- Replaced the custom Graph API client and dynamic feed rendering with the official Facebook Page iframe in `index.html` and added a `.facebook-embed-wrapper` for centering the iframe.
- Added a user-facing fallback note under the iframe linking to `https://www.facebook.com/knihkupka` and introduced `.facebook-embed-note` styles in `assets/css/main.scss` for readable alignment.
- Added `demo-preview.html` as a standalone static preview that contains the same iframe and fallback note for local demoing without Jekyll processing.
- Cleaned up formatting in `assets/css/main.scss` and removed the unused Graph API script and related markup.

### Testing
- Served the repository locally with `python3 -m http.server 4000` and the server started successfully.
- Captured a Playwright (Firefox) screenshot of `http://127.0.0.1:4000/demo-preview.html` which completed successfully and produced the artifact `browser:/tmp/codex_browser_invocations/c7ad42f5bbc64f81/artifacts/artifacts/demo-preview-firefox-v2.png`.
- Verified and committed changes to the working tree with `git status --short` and a commit including `index.html`, `assets/css/main.scss`, and `demo-preview.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1ed7d4ec8328a9d527b3f5154537)