### PR TITLE
Rework one-page top layout: full-width contact row, right-aligned hours, and hero slogan banner

### DIFF
--- a/_pages/navrh-struktury-a.md
+++ b/_pages/navrh-struktury-a.md
@@ -1,0 +1,80 @@
+---
+permalink: /navrh-struktury-a/
+title: "Návrh struktury A"
+layout: splash
+author_profile: false
+sitemap: false
+robots: noindex
+header:
+  overlay_image: /assets/images/background-home.jpg
+  overlay_filter: 0.5
+---
+
+<section class="redesign redesign--a">
+  <div class="redesign__grid redesign__grid--intro">
+    <article class="redesign__card">
+      <h2>Co u nás najdete</h2>
+      <p>Máme hodně knih pro děti, nějakou tu beletrii i trochu toho odborného, také deskové hry a audioknihy.</p>
+      <p>Pokud to půjde, objednáme na přání. <a href="mailto:knihkupka@knihkupka.cz">Napište nám</a>, o co máte zájem.</p>
+      <p>Zabalíme dárkově. Máte co číst?</p>
+    </article>
+
+    <article class="redesign__card">
+      <h2>Rychlý kontakt</h2>
+      <ul class="redesign__list">
+        <li><strong>Telefon:</strong> <a href="tel:+420607928760">607 928 760</a></li>
+        <li><strong>Email:</strong> <a href="mailto:knihkupka@knihkupka.cz">knihkupka@knihkupka.cz</a></li>
+        <li><strong>Adresa:</strong> Komenského nám. 105, Nové Strašecí</li>
+      </ul>
+      <a class="btn btn--primary" href="/kontakty/">Detail kontaktů</a>
+    </article>
+  </div>
+
+  <div class="redesign__grid redesign__grid--hours">
+    <article class="redesign__card">
+      <h2>Otevírací doba</h2>
+      <table>
+        <tbody>
+          <tr><td>Po - Pá</td><td>8:30 - 17:00</td></tr>
+          <tr><td>So</td><td>9:00 - 11:00</td></tr>
+          <tr><td>Ne</td><td>Zavřeno</td></tr>
+        </tbody>
+      </table>
+    </article>
+
+    <article class="redesign__card">
+      <h2>Sortiment</h2>
+      <ul class="redesign__list">
+        <li>Knihy pro děti</li>
+        <li>Beletrie i odborné tituly</li>
+        <li>Deskové hry</li>
+        <li>Audioknihy</li>
+        <li>Dárkové poukázky</li>
+      </ul>
+      <a class="btn" href="/about/">Fotogalerie prodejny</a>
+    </article>
+  </div>
+
+  <section class="homepage-section homepage-section--facebook">
+    <div class="facebook-embed-wrapper">
+      <iframe
+        title="Facebook stránka Knihkupka"
+        data-src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Fknihkupka&tabs=timeline&width=500&height=720&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=false&appId"
+        style="border:none;overflow:hidden"
+        scrolling="no"
+        frameborder="0"
+        allowfullscreen="true"
+        allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share">
+      </iframe>
+    </div>
+  </section>
+</section>
+
+<script>
+  var _fbA = document.querySelector('.redesign--a .facebook-embed-wrapper iframe[data-src]');
+  if (_fbA) {
+    var _wA = Math.min(500, Math.max(180, document.documentElement.clientWidth));
+    _fbA.src = _fbA.dataset.src.replace(/width=\d+/, 'width=' + _wA);
+    _fbA.style.width = _wA + 'px';
+  }
+</script>

--- a/_pages/navrh-struktury-b.md
+++ b/_pages/navrh-struktury-b.md
@@ -1,0 +1,55 @@
+---
+permalink: /navrh-struktury-b/
+title: "Návrh struktury B"
+layout: splash
+author_profile: false
+sitemap: false
+robots: noindex
+header:
+  overlay_image: /assets/images/background-home.jpg
+  overlay_filter: 0.5
+---
+
+<section class="redesign redesign--b">
+  <article class="redesign__card redesign__card--hero">
+    <h2>Malé knihkupectví v malém městě, ale něco se do něj vejde.</h2>
+    <p>Máme hodně knih pro děti, nějakou tu beletrii i trochu toho odborného, také deskové hry a audioknihy.</p>
+    <div class="redesign__actions">
+      <a class="btn btn--primary" href="/about/">O nás a fotky</a>
+      <a class="btn" href="/kontakty/">Kontakty a mapa</a>
+    </div>
+  </article>
+
+  <div class="redesign__timeline">
+    <article class="redesign__card">
+      <h3>1. Vyberte</h3>
+      <p>Knihy pro děti, beletrii, odborné tituly, deskovky nebo audioknihy.</p>
+    </article>
+    <article class="redesign__card">
+      <h3>2. Zeptáte se</h3>
+      <p>Pokud to půjde, objednáme na přání. <a href="mailto:knihkupka@knihkupka.cz">Stačí napsat</a>.</p>
+    </article>
+    <article class="redesign__card">
+      <h3>3. Odnesete</h3>
+      <p>Zabalíme dárkově a pomůžeme vybrat i poukázku.</p>
+    </article>
+  </div>
+
+  <div class="redesign__grid redesign__grid--contact-map">
+    <article class="redesign__card">
+      <h2>Kontakt a otevírací doba</h2>
+      <ul class="redesign__list">
+        <li><strong>Telefon:</strong> <a href="tel:+420607928760">607 928 760</a></li>
+        <li><strong>Email:</strong> <a href="mailto:knihkupka@knihkupka.cz">knihkupka@knihkupka.cz</a></li>
+        <li><strong>Po - Pá:</strong> 8:30 - 17:00</li>
+        <li><strong>So:</strong> 9:00 - 11:00</li>
+        <li><strong>Ne:</strong> Zavřeno</li>
+      </ul>
+      <p><strong>Komenského nám. 105, 271 01 Nové Strašecí</strong></p>
+    </article>
+
+    <article class="redesign__card redesign__card--map">
+      <iframe title="Mapa Knihkupky" style="border:none" src="https://frame.mapy.cz/s/fosavuluzu" width="700" height="466" frameborder="0"></iframe>
+    </article>
+  </div>
+</section>

--- a/_pages/navrh-struktury-c.md
+++ b/_pages/navrh-struktury-c.md
@@ -1,0 +1,99 @@
+---
+permalink: /navrh-struktury-c/
+title: "Návrh struktury C"
+layout: splash
+author_profile: false
+sitemap: false
+robots: noindex
+header:
+  overlay_image: /assets/images/background-home.jpg
+  overlay_filter: 0.5
+---
+
+<section class="redesign redesign--c">
+  <article class="redesign__card redesign__card--hero">
+    <h2>Malé knihkupectví v malém městě, ale něco se do něj vejde.</h2>
+    <p>Máme hodně knih pro děti, nějakou tu beletrii i trochu toho odborného, také deskové hry a audioknihy.</p>
+    <div class="redesign__actions">
+      <a class="btn btn--primary" href="/kontakty/">Zavolat a naplánovat návštěvu</a>
+      <a class="btn" href="/about/">Podívat se na prodejnu</a>
+    </div>
+  </article>
+
+  <div class="redesign__grid redesign__grid--quickinfo">
+    <article class="redesign__card">
+      <h3>Rychlý kontakt</h3>
+      <ul class="redesign__list">
+        <li><strong>Telefon:</strong> <a href="tel:+420607928760">607 928 760</a></li>
+        <li><strong>Email:</strong> <a href="mailto:knihkupka@knihkupka.cz">knihkupka@knihkupka.cz</a></li>
+        <li><strong>Adresa:</strong> Komenského nám. 105, Nové Strašecí</li>
+      </ul>
+    </article>
+
+    <article class="redesign__card">
+      <h3>Otevírací doba</h3>
+      <table>
+        <tbody>
+          <tr><td>Po - Pá</td><td>8:30 - 17:00</td></tr>
+          <tr><td>So</td><td>9:00 - 11:00</td></tr>
+          <tr><td>Ne</td><td>Zavřeno</td></tr>
+        </tbody>
+      </table>
+    </article>
+
+    <article class="redesign__card">
+      <h3>Co u nás najdete</h3>
+      <ul class="redesign__list">
+        <li>Knihy pro děti</li>
+        <li>Beletrie i odborné tituly</li>
+        <li>Deskové hry a audioknihy</li>
+        <li>Dárkové poukázky</li>
+      </ul>
+    </article>
+  </div>
+
+  <div class="redesign__timeline">
+    <article class="redesign__card">
+      <h3>1. Vyberte</h3>
+      <p>Knihy, deskovky nebo audioknihy podle věku i nálady.</p>
+    </article>
+    <article class="redesign__card">
+      <h3>2. Zeptáte se</h3>
+      <p>Když titul nemáme, pokusíme se ho objednat na přání.</p>
+    </article>
+    <article class="redesign__card">
+      <h3>3. Odnesete</h3>
+      <p>Zabalíme dárkově a poradíme i s výběrem poukázky.</p>
+    </article>
+  </div>
+
+  <div class="redesign__grid redesign__grid--contact-map">
+    <article class="redesign__card redesign__card--map">
+      <iframe title="Mapa Knihkupky" style="border:none" src="https://frame.mapy.cz/s/fosavuluzu" width="700" height="466" frameborder="0"></iframe>
+    </article>
+
+    <article class="redesign__card redesign__card--feed">
+      <h3>Aktuálně z Facebooku</h3>
+      <div class="facebook-embed-wrapper">
+        <iframe
+          title="Facebook stránka Knihkupka"
+          data-src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Fknihkupka&tabs=timeline&width=500&height=720&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=false&appId"
+          style="border:none;overflow:hidden"
+          scrolling="no"
+          frameborder="0"
+          allowfullscreen="true"
+          allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share">
+        </iframe>
+      </div>
+    </article>
+  </div>
+</section>
+
+<script>
+  var _fbC = document.querySelector('.redesign--c .facebook-embed-wrapper iframe[data-src]');
+  if (_fbC) {
+    var _wC = Math.min(500, Math.max(180, document.documentElement.clientWidth));
+    _fbC.src = _fbC.dataset.src.replace(/width=\d+/, 'width=' + _wC);
+    _fbC.style.width = _wC + 'px';
+  }
+</script>

--- a/_pages/navrh-struktury.md
+++ b/_pages/navrh-struktury.md
@@ -1,0 +1,16 @@
+---
+permalink: /navrh-struktury/
+title: "Skryté návrhy struktury"
+layout: single
+author_profile: false
+sitemap: false
+robots: noindex
+---
+
+Tato stránka slouží pouze k internímu porovnání struktur homepage.
+
+- [Návrh A](/navrh-struktury-a/)
+- [Návrh B](/navrh-struktury-b/)
+- [Návrh C](/navrh-struktury-c/)
+
+- [One-page HTML/CSS návrh](/navrh-jednostrankovy.html)

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -107,7 +107,7 @@ body {
 // ============================================================
 .site-logo img {
   padding-top: 0.1rem;
-  max-height: 2.7rem;
+  max-height: 10.8rem;
 }
 
 // ============================================================
@@ -134,4 +134,76 @@ body {
   margin-top: 0.75rem;
   text-align: center;
   font-size: 0.95rem;
+}
+
+// ============================================================
+// HIDDEN REDESIGN VARIANTS
+// ============================================================
+.redesign {
+  margin-top: 1.5rem;
+}
+
+.redesign__grid {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.redesign__grid--intro,
+.redesign__grid--hours,
+.redesign__grid--contact-map {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.redesign__card {
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid #e6ccaf;
+  border-radius: 0.6rem;
+  padding: 1rem 1.2rem;
+}
+
+.redesign__list {
+  margin: 0.3rem 0 1rem;
+}
+
+.redesign__list li {
+  margin-bottom: 0.35rem;
+}
+
+.redesign__timeline {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-bottom: 1rem;
+}
+
+.redesign__card--hero {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.redesign__actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+.redesign__card--map iframe {
+  width: 100%;
+  min-height: 320px;
+}
+
+.redesign__grid--quickinfo {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.redesign__card--feed h3 {
+  margin-top: 0;
+}
+
+.redesign--c .redesign__card--feed .facebook-embed-wrapper iframe {
+  width: 100%;
+  max-width: 500px;
 }

--- a/navrh-jednostrankovy.html
+++ b/navrh-jednostrankovy.html
@@ -1,0 +1,289 @@
+<!doctype html>
+<html lang="cs">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
+  <title>Knihkupka — návrh one-page (HTML/CSS)</title>
+  <style>
+    @font-face {
+      font-family: "Literata";
+      src: url("/assets/fonts/Literata-Bold.woff2") format("woff2");
+      font-weight: 700;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    :root {
+      --bg: #f7f1eb;
+      --text: #240F0A;
+      --accent: #E3A856;
+      --line: #e6ccaf;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      line-height: 1.55;
+    }
+
+    .page {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 1.2rem 1rem 0;
+    }
+
+    .top-contact-wrap {
+      width: 100%;
+      background: #240F0A;
+    }
+
+    .top-contact-inner {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: .7rem 1rem;
+    }
+
+    h1, h2, h3 {
+      font-family: "Literata", Georgia, "Times New Roman", serif;
+      line-height: 1.2;
+      margin: 0 0 .7rem;
+      color: var(--text);
+    }
+
+    p, li, td, a, small, .muted { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+
+    .logo-float {
+      float: left;
+      width: min(42vw, 460px);
+      margin: 1.8rem 4ch 2.2rem 0;
+      padding: .4rem;
+      background: var(--bg);
+    }
+
+    .logo-float img {
+      width: 100%;
+      height: auto;
+      display: block;
+    }
+
+    .logo-tagline {
+      margin: .45rem 0 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      font-size: clamp(1rem, 2.05vw, 1.85rem);
+      line-height: 1.15;
+      text-align: center;
+      white-space: nowrap;
+      color: var(--text);
+    }
+
+    .contact-strip {
+      color: #f7f1eb;
+      text-align: right;
+      padding: 0;
+      margin: 0;
+    }
+
+    .contact-list {
+      list-style: none;
+      display: flex;
+      flex-wrap: nowrap;
+      justify-content: flex-end;
+      gap: 1rem 1.6rem;
+      padding: 0;
+      margin: 0;
+      font-weight: 600;
+      white-space: nowrap;
+      overflow-x: auto;
+    }
+
+    .contact-list a { color: #f7f1eb; text-decoration: none; border-bottom: 1px solid transparent; }
+    .intro-flow { margin-top: .1rem; margin-left: min(42vw, 460px); }
+    .contact-list a:hover { border-color: var(--accent); }
+    .icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.25rem;
+      height: 1.25rem;
+      margin-right: .35rem;
+      vertical-align: -0.15rem;
+    }
+    .icon svg { width: 100%; height: 100%; fill: currentColor; }
+
+    section {
+      padding: .35rem 0 1rem;
+      margin-bottom: .2rem;
+    }
+
+    .below-logo {
+      clear: both;
+    }
+
+    .slogan-banner {
+      clear: both;
+      margin: .6rem 0 1.6rem;
+      padding: 3rem 1rem;
+      background-image: linear-gradient(rgba(36,15,10,.42), rgba(36,15,10,.42)), url('/assets/images/background-home.jpg');
+      background-size: cover;
+      background-position: center;
+      color: #fff;
+      text-align: center;
+    }
+
+    .slogan-banner p {
+      margin: 0;
+      color: #fff;
+      font-family: "Literata", Georgia, "Times New Roman", serif;
+      font-size: clamp(1.5rem, 3.1vw, 2.4rem);
+      line-height: 1.2;
+    }
+
+
+    .hours { text-align: right; }
+    .hours table { border-collapse: collapse; width: 100%; max-width: 460px; margin-left: auto; }
+    .hours h2 { text-align: right; }
+    .hours td { border-bottom: 1px solid var(--line); padding: .4rem .1rem; text-align: right; }
+
+    .fb-float {
+      float: right;
+      width: 40%;
+      min-width: 290px;
+      margin: 0 0 .9rem 1rem;
+      padding: .1rem;
+    }
+
+    .fb-float iframe { width: 100%; height: 620px; border: none; }
+
+    .gallery {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: .7rem;
+      margin-top: .8rem;
+    }
+
+    .gallery img {
+      width: 100%;
+      height: 210px;
+      object-fit: cover;
+    }
+
+    .address-map {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: 1fr 1.6fr;
+      align-items: start;
+    }
+
+    .map iframe { width: 100%; min-height: 360px; border: none; }
+
+    footer {
+      margin-top: 1.2rem;
+      width: 100%;
+      background: var(--text);
+      color: #f7f1eb;
+      padding: 1rem;
+    }
+
+    footer .inner { max-width: 1180px; margin: 0 auto; }
+    footer h3 { color: #fff; margin-bottom: .4rem; }
+    footer p { margin: .25rem 0; }
+
+    @media (max-width: 920px) {
+      .logo-float { float: none; width: min(100%, 520px); margin: 1.2rem 0 1.6rem; }
+      .logo-tagline { white-space: normal; }
+      .intro-flow { margin-left: 0; }
+      .fb-float { float: none; width: 100%; min-width: 0; margin-left: 0; }
+      .address-map { grid-template-columns: 1fr; }
+      .gallery { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <div class="top-contact-wrap">
+    <div class="top-contact-inner">
+      <section class="contact-strip" aria-label="Kontakty">
+        <ul class="contact-list">
+        <li><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M6.62 10.79a15.05 15.05 0 0 0 6.59 6.59l2.2-2.2a1 1 0 0 1 1-.24c1.12.37 2.33.56 3.59.56a1 1 0 0 1 1 1V20a1 1 0 0 1-1 1C10.3 21 3 13.7 3 4a1 1 0 0 1 1-1h3.5a1 1 0 0 1 1 1c0 1.26.19 2.47.56 3.59a1 1 0 0 1-.24 1z"/></svg></span><a href="tel:+420607928760">607 928 760</a></li>
+        <li><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M20.52 3.48A11.86 11.86 0 0 0 12.07 0C5.5 0 .16 5.34.16 11.91c0 2.1.55 4.15 1.6 5.96L0 24l6.3-1.65a11.88 11.88 0 0 0 5.77 1.47h.01c6.57 0 11.91-5.34 11.91-11.91 0-3.18-1.24-6.17-3.47-8.43zM12.08 21.8h-.01a9.9 9.9 0 0 1-5.03-1.37l-.36-.21-3.74.98 1-3.64-.23-.37a9.9 9.9 0 0 1-1.53-5.28c0-5.47 4.45-9.92 9.92-9.92 2.65 0 5.13 1.03 7 2.9a9.86 9.86 0 0 1 2.9 7c0 5.47-4.45 9.91-9.92 9.91zm5.44-7.42c-.3-.15-1.77-.87-2.05-.97-.27-.1-.47-.15-.67.15-.2.3-.77.97-.95 1.16-.17.2-.35.22-.65.08-.3-.15-1.28-.47-2.43-1.5-.9-.8-1.5-1.8-1.68-2.1-.17-.3-.02-.46.13-.6.14-.14.3-.35.45-.52.15-.17.2-.3.3-.5.1-.2.05-.37-.02-.52-.08-.15-.67-1.62-.92-2.22-.24-.58-.48-.5-.67-.51h-.57c-.2 0-.52.07-.8.37-.27.3-1.05 1.03-1.05 2.5s1.08 2.9 1.23 3.1c.15.2 2.12 3.24 5.14 4.54.72.31 1.28.5 1.72.64.72.23 1.38.2 1.9.12.58-.09 1.77-.72 2.02-1.42.25-.7.25-1.29.17-1.42-.07-.12-.27-.2-.57-.35z"/></svg></span><a href="https://wa.me/420607928760">WhatsApp</a></li>
+        <li><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M22 12a10 10 0 1 0-11.56 9.88v-6.99H7.9V12h2.54V9.8c0-2.5 1.49-3.88 3.77-3.88 1.09 0 2.24.19 2.24.19v2.46H15.2c-1.24 0-1.63.77-1.63 1.56V12h2.78l-.44 2.89h-2.34v6.99A10 10 0 0 0 22 12"/></svg></span><a href="https://www.facebook.com/knihkupka">Facebook /knihkupka</a></li>
+        <li><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 2 3 8v12h18V8zm0 2.2L19 9v9H5V9zM8 11h8v2H8zm0 3h8v2H8z"/></svg></span><a href="#kde-nas-najdete">Komenského nám. 105, 271 01 Nové Strašecí</a></li>
+        </ul>
+      </section>
+    </div>
+  </div>
+
+  <main class="page">
+    <div class="logo-float">
+      <img src="/assets/images/logo.svg" alt="Knihkupka logo">
+      <p class="logo-tagline">Knihkupectví v Novém Strašecí</p>
+    </div>
+
+    <section class="hours intro-flow" aria-labelledby="oteviraci-doba">
+      <h2 id="oteviraci-doba">Otevírací doba</h2>
+      <table>
+        <tbody>
+          <tr><td>Po - Pá</td><td>8:30 - 17:00</td></tr>
+          <tr><td>So</td><td>9:00 - 11:00</td></tr>
+          <tr><td>Ne</td><td>Zavřeno</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="slogan-banner" aria-label="Slogan knihkupectví">
+      <p>Malé knihkupectví v malém městě, ale něco se do něj vejde.</p>
+    </section>
+
+    <section class="below-logo" aria-labelledby="onas-a-fotky">
+      <aside class="fb-float">
+        <iframe
+          title="Facebook stránka Knihkupka"
+          src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Fknihkupka&tabs=timeline&width=500&height=720&small_header=true&adapt_container_width=true&hide_cover=true&show_facepile=false&appId"
+          loading="lazy"
+          allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share">
+        </iframe>
+      </aside>
+
+      <h2 id="onas-a-fotky">O nás</h2>
+      <p>Máme hodně knih pro děti, nějakou tu beletrii i trochu toho odborného, také deskové hry a audioknihy.</p>
+      <p>Pokud to půjde, objednáme na přání. <a href="mailto:knihkupka@knihkupka.cz">Napište nám</a>, o co máte zájem.</p>
+      <p>Zabalíme dárkově. Máte co číst?</p>
+
+      <div class="gallery" aria-label="Fotogalerie prodejny">
+        <img src="/assets/images/bookshelves.jpg" alt="Knihovnička">
+        <img src="/assets/images/boardgames.jpg" alt="Deskovky">
+        <img src="/assets/images/counter.jpg" alt="Za kasou">
+        <img src="/assets/images/bookshelves-2.jpg" alt="Další knihovnička">
+        <img src="/assets/images/poukazka.jpg" alt="Dárkové poukázky">
+      </div>
+    </section>
+
+    <section class="address-map" aria-labelledby="kde-nas-najdete">
+      <div>
+        <h2 id="kde-nas-najdete">Kde nás najdete</h2>
+        <p>
+          Komenského nám. 105<br>
+          271 01 Nové Strašecí
+        </p>
+      </div>
+      <div class="map">
+        <iframe title="Mapa Knihkupka" src="https://frame.mapy.cz/s/fosavuluzu" loading="lazy"></iframe>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="inner">
+      <h3>Provozovatel</h3>
+      <p>Dita Albrechtová</p>
+      <p>IČO: 21282030</p>
+      <p>nám. 1. máje 57, 270 62 Rynholec</p>
+      <p><small>Podnikatelka zapsaná v živnostenském rejstříku. Úřad příslušný podle §71 odst.2 živnostenského zákona: Městský úřad Rakovník.</small></p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/navrh-jednostrankovy.html
+++ b/navrh-jednostrankovy.html
@@ -59,7 +59,7 @@
 
     .logo-float {
       float: left;
-      width: min(42vw, 460px);
+      width: min(31vw, 340px);
       margin: 1.8rem 4ch 2.2rem 0;
       padding: .4rem;
       background: var(--bg);
@@ -102,7 +102,23 @@
     }
 
     .contact-list a { color: #f7f1eb; text-decoration: none; border-bottom: 1px solid transparent; }
-    .intro-flow { margin-top: .1rem; margin-left: min(42vw, 460px); }
+    .intro-flow { margin-top: .1rem; margin-left: min(31vw, 340px); }
+
+    .address-inline {
+      text-align: right;
+      padding-bottom: .2rem;
+    }
+
+    .address-inline a {
+      color: var(--text);
+      text-decoration: none;
+      border-bottom: 1px solid var(--line);
+      font-weight: 600;
+    }
+
+    .address-inline .icon {
+      color: var(--text);
+    }
     .contact-list a:hover { border-color: var(--accent); }
     .icon {
       display: inline-flex;
@@ -126,8 +142,11 @@
 
     .slogan-banner {
       clear: both;
-      margin: .6rem 0 1.6rem;
-      padding: 3rem 1rem;
+      margin: .8rem 0 1.4rem;
+      padding: 1.05rem 1rem;
+      width: 100vw;
+      margin-left: calc(50% - 50vw);
+      margin-right: calc(50% - 50vw);
       background-image: linear-gradient(rgba(36,15,10,.42), rgba(36,15,10,.42)), url('assets/images/background-home.jpg');
       background-size: cover;
       background-position: center;
@@ -138,9 +157,9 @@
     .slogan-banner p {
       margin: 0;
       color: #fff;
-      font-family: "Literata", Georgia, "Times New Roman", serif;
-      font-size: clamp(1.5rem, 3.1vw, 2.4rem);
-      line-height: 1.2;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      font-size: clamp(1rem, 2.05vw, 1.85rem);
+      line-height: 1.25;
     }
 
 
@@ -197,6 +216,7 @@
       .logo-float { float: none; width: min(100%, 520px); margin: 1.2rem 0 1.6rem; }
       .logo-tagline { white-space: normal; }
       .intro-flow { margin-left: 0; }
+      .address-inline { text-align: left; }
       .fb-float { float: none; width: 100%; min-width: 0; margin-left: 0; }
       .address-map { grid-template-columns: 1fr; }
       .gallery { grid-template-columns: 1fr; }
@@ -211,7 +231,6 @@
         <li><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M6.62 10.79a15.05 15.05 0 0 0 6.59 6.59l2.2-2.2a1 1 0 0 1 1-.24c1.12.37 2.33.56 3.59.56a1 1 0 0 1 1 1V20a1 1 0 0 1-1 1C10.3 21 3 13.7 3 4a1 1 0 0 1 1-1h3.5a1 1 0 0 1 1 1c0 1.26.19 2.47.56 3.59a1 1 0 0 1-.24 1z"/></svg></span><a href="tel:+420607928760">607 928 760</a></li>
         <li><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M20.52 3.48A11.86 11.86 0 0 0 12.07 0C5.5 0 .16 5.34.16 11.91c0 2.1.55 4.15 1.6 5.96L0 24l6.3-1.65a11.88 11.88 0 0 0 5.77 1.47h.01c6.57 0 11.91-5.34 11.91-11.91 0-3.18-1.24-6.17-3.47-8.43zM12.08 21.8h-.01a9.9 9.9 0 0 1-5.03-1.37l-.36-.21-3.74.98 1-3.64-.23-.37a9.9 9.9 0 0 1-1.53-5.28c0-5.47 4.45-9.92 9.92-9.92 2.65 0 5.13 1.03 7 2.9a9.86 9.86 0 0 1 2.9 7c0 5.47-4.45 9.91-9.92 9.91zm5.44-7.42c-.3-.15-1.77-.87-2.05-.97-.27-.1-.47-.15-.67.15-.2.3-.77.97-.95 1.16-.17.2-.35.22-.65.08-.3-.15-1.28-.47-2.43-1.5-.9-.8-1.5-1.8-1.68-2.1-.17-.3-.02-.46.13-.6.14-.14.3-.35.45-.52.15-.17.2-.3.3-.5.1-.2.05-.37-.02-.52-.08-.15-.67-1.62-.92-2.22-.24-.58-.48-.5-.67-.51h-.57c-.2 0-.52.07-.8.37-.27.3-1.05 1.03-1.05 2.5s1.08 2.9 1.23 3.1c.15.2 2.12 3.24 5.14 4.54.72.31 1.28.5 1.72.64.72.23 1.38.2 1.9.12.58-.09 1.77-.72 2.02-1.42.25-.7.25-1.29.17-1.42-.07-.12-.27-.2-.57-.35z"/></svg></span><a href="https://wa.me/420607928760">WhatsApp</a></li>
         <li><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M22 12a10 10 0 1 0-11.56 9.88v-6.99H7.9V12h2.54V9.8c0-2.5 1.49-3.88 3.77-3.88 1.09 0 2.24.19 2.24.19v2.46H15.2c-1.24 0-1.63.77-1.63 1.56V12h2.78l-.44 2.89h-2.34v6.99A10 10 0 0 0 22 12"/></svg></span><a href="https://www.facebook.com/knihkupka">Facebook /knihkupka</a></li>
-        <li><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 2 3 8v12h18V8zm0 2.2L19 9v9H5V9zM8 11h8v2H8zm0 3h8v2H8z"/></svg></span><a href="#kde-nas-najdete">Komenského nám. 105, 271 01 Nové Strašecí</a></li>
         </ul>
       </section>
     </div>
@@ -222,6 +241,12 @@
       <img src="assets/images/logo.svg" alt="Knihkupka logo">
       <p class="logo-tagline">Knihkupectví v Novém Strašecí</p>
     </div>
+
+    <section class="address-inline intro-flow" aria-label="Adresa">
+      <p>
+        <span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 3.2 3.5 9.5V21h17V9.5L12 3.2zm0 2.4 6.3 4.6v8.9H5.7v-8.9L12 5.6zm-2.6 6h5.2v5.1H9.4z"/></svg></span><a href="https://frame.mapy.cz/s/fosavuluzu">Komenského nám. 105, 271 01 Nové Strašecí</a>
+      </p>
+    </section>
 
     <section class="hours intro-flow" aria-labelledby="oteviraci-doba">
       <h2 id="oteviraci-doba">Otevírací doba</h2>
@@ -235,7 +260,7 @@
     </section>
 
     <section class="slogan-banner" aria-label="Slogan knihkupectví">
-      <p>Malé knihkupectví v malém městě, ale něco se do něj vejde.</p>
+      <p>Malé knihkupectví v malém městě, ale něco se do něj vejde. Máte co číst?</p>
     </section>
 
     <section class="below-logo" aria-labelledby="onas-a-fotky">

--- a/navrh-jednostrankovy.html
+++ b/navrh-jednostrankovy.html
@@ -8,7 +8,7 @@
   <style>
     @font-face {
       font-family: "Literata";
-      src: url("/assets/fonts/Literata-Bold.woff2") format("woff2");
+      src: url("assets/fonts/Literata-Bold.woff2") format("woff2");
       font-weight: 700;
       font-style: normal;
       font-display: swap;
@@ -128,7 +128,7 @@
       clear: both;
       margin: .6rem 0 1.6rem;
       padding: 3rem 1rem;
-      background-image: linear-gradient(rgba(36,15,10,.42), rgba(36,15,10,.42)), url('/assets/images/background-home.jpg');
+      background-image: linear-gradient(rgba(36,15,10,.42), rgba(36,15,10,.42)), url('assets/images/background-home.jpg');
       background-size: cover;
       background-position: center;
       color: #fff;
@@ -219,7 +219,7 @@
 
   <main class="page">
     <div class="logo-float">
-      <img src="/assets/images/logo.svg" alt="Knihkupka logo">
+      <img src="assets/images/logo.svg" alt="Knihkupka logo">
       <p class="logo-tagline">Knihkupectví v Novém Strašecí</p>
     </div>
 
@@ -254,11 +254,11 @@
       <p>Zabalíme dárkově. Máte co číst?</p>
 
       <div class="gallery" aria-label="Fotogalerie prodejny">
-        <img src="/assets/images/bookshelves.jpg" alt="Knihovnička">
-        <img src="/assets/images/boardgames.jpg" alt="Deskovky">
-        <img src="/assets/images/counter.jpg" alt="Za kasou">
-        <img src="/assets/images/bookshelves-2.jpg" alt="Další knihovnička">
-        <img src="/assets/images/poukazka.jpg" alt="Dárkové poukázky">
+        <img src="assets/images/bookshelves.jpg" alt="Knihovnička">
+        <img src="assets/images/boardgames.jpg" alt="Deskovky">
+        <img src="assets/images/counter.jpg" alt="Za kasou">
+        <img src="assets/images/bookshelves-2.jpg" alt="Další knihovnička">
+        <img src="assets/images/poukazka.jpg" alt="Dárkové poukázky">
       </div>
     </section>
 

--- a/navrh-jednostrankovy.html
+++ b/navrh-jednostrankovy.html
@@ -138,6 +138,10 @@
 
     .below-logo {
       clear: both;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1.25rem;
+      align-items: start;
     }
 
     .slogan-banner {
@@ -169,26 +173,42 @@
     .hours td { border-bottom: 1px solid var(--line); padding: .4rem .1rem; text-align: right; }
 
     .fb-float {
-      float: right;
-      width: 40%;
-      min-width: 290px;
-      margin: 0 0 .9rem 1rem;
+      width: 100%;
+      min-width: 0;
+      margin: 0;
       padding: .1rem;
+      grid-column: 2;
     }
 
-    .fb-float iframe { width: 100%; height: 620px; border: none; }
+    .fb-float iframe { width: 100%; height: 780px; border: none; }
+
+    .content-column {
+      grid-column: 1;
+      min-width: 0;
+    }
 
     .gallery {
       display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: .7rem;
+      grid-template-columns: 1fr;
+      gap: .65rem;
       margin-top: .8rem;
+      max-width: 100%;
     }
 
     .gallery img {
       width: 100%;
-      height: 210px;
+      max-width: 280px;
+      height: 158px;
       object-fit: cover;
+      border-radius: 4px;
+      scroll-snap-align: start;
+    }
+
+    .photo-reel {
+      max-height: 520px;
+      overflow-y: auto;
+      scroll-snap-type: y proximity;
+      padding-right: .25rem;
     }
 
     .address-map {
@@ -218,9 +238,12 @@
       .logo-tagline { white-space: normal; }
       .intro-flow { margin-left: 0; }
       .address-inline { text-align: left; }
-      .fb-float { float: none; width: 100%; min-width: 0; margin-left: 0; }
+      .below-logo { grid-template-columns: 1fr; }
+      .content-column, .fb-float { grid-column: auto; }
+      .fb-float iframe { height: 620px; }
+      .photo-reel { max-height: none; overflow: visible; }
+      .gallery img { max-width: 100%; height: 170px; }
       .address-map { grid-template-columns: 1fr; }
-      .gallery { grid-template-columns: 1fr; }
     }
   </style>
 </head>
@@ -266,6 +289,23 @@
     </section>
 
     <section class="below-logo" aria-labelledby="onas-a-fotky">
+      <div class="content-column">
+        <h2 id="onas-a-fotky">O nás</h2>
+        <p>Máme hodně knih pro děti, nějakou tu beletrii i trochu toho odborného, také deskové hry a audioknihy.</p>
+        <p>Pokud to půjde, objednáme na přání. <a href="mailto:knihkupka@knihkupka.cz">Napište nám</a>, o co máte zájem.</p>
+        <p>Zabalíme dárkově. Máte co číst?</p>
+
+        <div class="photo-reel" aria-label="Fotogalerie prodejny — svislý reel">
+          <div class="gallery" aria-label="Fotogalerie prodejny">
+            <img src="assets/images/bookshelves.jpg" alt="Knihovnička">
+            <img src="assets/images/boardgames.jpg" alt="Deskovky">
+            <img src="assets/images/counter.jpg" alt="Za kasou">
+            <img src="assets/images/bookshelves-2.jpg" alt="Další knihovnička">
+            <img src="assets/images/poukazka.jpg" alt="Dárkové poukázky">
+          </div>
+        </div>
+      </div>
+
       <aside class="fb-float">
         <iframe
           title="Facebook stránka Knihkupka"
@@ -274,19 +314,6 @@
           allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share">
         </iframe>
       </aside>
-
-      <h2 id="onas-a-fotky">O nás</h2>
-      <p>Máme hodně knih pro děti, nějakou tu beletrii i trochu toho odborného, také deskové hry a audioknihy.</p>
-      <p>Pokud to půjde, objednáme na přání. <a href="mailto:knihkupka@knihkupka.cz">Napište nám</a>, o co máte zájem.</p>
-      <p>Zabalíme dárkově. Máte co číst?</p>
-
-      <div class="gallery" aria-label="Fotogalerie prodejny">
-        <img src="assets/images/bookshelves.jpg" alt="Knihovnička">
-        <img src="assets/images/boardgames.jpg" alt="Deskovky">
-        <img src="assets/images/counter.jpg" alt="Za kasou">
-        <img src="assets/images/bookshelves-2.jpg" alt="Další knihovnička">
-        <img src="assets/images/poukazka.jpg" alt="Dárkové poukázky">
-      </div>
     </section>
 
     <section class="address-map" aria-labelledby="kde-nas-najdete">

--- a/navrh-jednostrankovy.html
+++ b/navrh-jednostrankovy.html
@@ -59,7 +59,7 @@
 
     .logo-float {
       float: left;
-      width: min(31vw, 340px);
+      width: min(26vw, 290px);
       margin: 1.8rem 4ch 2.2rem 0;
       padding: .4rem;
       background: var(--bg);
@@ -74,7 +74,7 @@
     .logo-tagline {
       margin: .45rem 0 0;
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-      font-size: clamp(1rem, 2.05vw, 1.85rem);
+      font-size: clamp(.88rem, 1.55vw, 1.35rem);
       line-height: 1.15;
       text-align: center;
       white-space: nowrap;
@@ -102,7 +102,7 @@
     }
 
     .contact-list a { color: #f7f1eb; text-decoration: none; border-bottom: 1px solid transparent; }
-    .intro-flow { margin-top: .1rem; margin-left: min(31vw, 340px); }
+    .intro-flow { margin-top: .1rem; margin-left: min(26vw, 290px); }
 
     .address-inline {
       text-align: right;
@@ -158,7 +158,7 @@
       margin: 0;
       color: #fff;
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-      font-size: clamp(1rem, 2.05vw, 1.85rem);
+      font-size: clamp(.88rem, 1.55vw, 1.35rem);
       line-height: 1.25;
     }
 
@@ -211,6 +211,7 @@
     footer .inner { max-width: 1180px; margin: 0 auto; }
     footer h3 { color: #fff; margin-bottom: .4rem; }
     footer p { margin: .25rem 0; }
+    footer a { color: #f7f1eb; }
 
     @media (max-width: 920px) {
       .logo-float { float: none; width: min(100%, 520px); margin: 1.2rem 0 1.6rem; }
@@ -230,7 +231,8 @@
         <ul class="contact-list">
         <li><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M6.62 10.79a15.05 15.05 0 0 0 6.59 6.59l2.2-2.2a1 1 0 0 1 1-.24c1.12.37 2.33.56 3.59.56a1 1 0 0 1 1 1V20a1 1 0 0 1-1 1C10.3 21 3 13.7 3 4a1 1 0 0 1 1-1h3.5a1 1 0 0 1 1 1c0 1.26.19 2.47.56 3.59a1 1 0 0 1-.24 1z"/></svg></span><a href="tel:+420607928760">607 928 760</a></li>
         <li><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M20.52 3.48A11.86 11.86 0 0 0 12.07 0C5.5 0 .16 5.34.16 11.91c0 2.1.55 4.15 1.6 5.96L0 24l6.3-1.65a11.88 11.88 0 0 0 5.77 1.47h.01c6.57 0 11.91-5.34 11.91-11.91 0-3.18-1.24-6.17-3.47-8.43zM12.08 21.8h-.01a9.9 9.9 0 0 1-5.03-1.37l-.36-.21-3.74.98 1-3.64-.23-.37a9.9 9.9 0 0 1-1.53-5.28c0-5.47 4.45-9.92 9.92-9.92 2.65 0 5.13 1.03 7 2.9a9.86 9.86 0 0 1 2.9 7c0 5.47-4.45 9.91-9.92 9.91zm5.44-7.42c-.3-.15-1.77-.87-2.05-.97-.27-.1-.47-.15-.67.15-.2.3-.77.97-.95 1.16-.17.2-.35.22-.65.08-.3-.15-1.28-.47-2.43-1.5-.9-.8-1.5-1.8-1.68-2.1-.17-.3-.02-.46.13-.6.14-.14.3-.35.45-.52.15-.17.2-.3.3-.5.1-.2.05-.37-.02-.52-.08-.15-.67-1.62-.92-2.22-.24-.58-.48-.5-.67-.51h-.57c-.2 0-.52.07-.8.37-.27.3-1.05 1.03-1.05 2.5s1.08 2.9 1.23 3.1c.15.2 2.12 3.24 5.14 4.54.72.31 1.28.5 1.72.64.72.23 1.38.2 1.9.12.58-.09 1.77-.72 2.02-1.42.25-.7.25-1.29.17-1.42-.07-.12-.27-.2-.57-.35z"/></svg></span><a href="https://wa.me/420607928760">WhatsApp</a></li>
-        <li><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M22 12a10 10 0 1 0-11.56 9.88v-6.99H7.9V12h2.54V9.8c0-2.5 1.49-3.88 3.77-3.88 1.09 0 2.24.19 2.24.19v2.46H15.2c-1.24 0-1.63.77-1.63 1.56V12h2.78l-.44 2.89h-2.34v6.99A10 10 0 0 0 22 12"/></svg></span><a href="https://www.facebook.com/knihkupka">Facebook /knihkupka</a></li>
+        <li><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M3 5h18a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1zm0 2v.2l9 6.3 9-6.3V7l-9 6.3L3 7zm0 2.64V17h18V9.64l-8.43 5.9a1 1 0 0 1-1.14 0z"/></svg></span><a href="mailto:knihkupka@knihkupka.cz">knihkupka@knihkupka.cz</a></li>
+        <li><span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M22 12a10 10 0 1 0-11.56 9.88v-6.99H7.9V12h2.54V9.8c0-2.5 1.49-3.88 3.77-3.88 1.09 0 2.24.19 2.24.19v2.46H15.2c-1.24 0-1.63.77-1.63 1.56V12h2.78l-.44 2.89h-2.34v6.99A10 10 0 0 0 22 12"/></svg></span><a href="https://www.facebook.com/knihkupka">Facebook</a></li>
         </ul>
       </section>
     </div>
@@ -244,7 +246,7 @@
 
     <section class="address-inline intro-flow" aria-label="Adresa">
       <p>
-        <span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 3.2 3.5 9.5V21h17V9.5L12 3.2zm0 2.4 6.3 4.6v8.9H5.7v-8.9L12 5.6zm-2.6 6h5.2v5.1H9.4z"/></svg></span><a href="https://frame.mapy.cz/s/fosavuluzu">Komenského nám. 105, 271 01 Nové Strašecí</a>
+        <span class="icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 3.2 3.5 9.5V21h17V9.5L12 3.2zm0 2.4 6.3 4.6v8.9H5.7v-8.9L12 5.6zm-2.6 6h5.2v5.1H9.4z"/></svg></span><a href="#kde-nas-najdete">Komenského nám. 105, 271 01 Nové Strašecí</a>
       </p>
     </section>
 
@@ -303,6 +305,12 @@
 
   <footer>
     <div class="inner">
+      <h3>Kontakty</h3>
+      <p><a href="tel:+420607928760">Telefon: 607 928 760</a> · <a href="https://wa.me/420607928760">WhatsApp</a></p>
+      <p><a href="mailto:knihkupka@knihkupka.cz">E-mail: knihkupka@knihkupka.cz</a></p>
+      <p><a href="https://www.facebook.com/knihkupka">Facebook</a></p>
+      <p><a href="#kde-nas-najdete">Komenského nám. 105, 271 01 Nové Strašecí</a></p>
+
       <h3>Provozovatel</h3>
       <p>Dita Albrechtová</p>
       <p>IČO: 21282030</p>


### PR DESCRIPTION
### Implemented requested changes
Updated `navrh-jednostrankovy.html` to match all four points:

1. **Full-width one-line contact strip + logo moved below**
   - Added a full-width top bar (`.top-contact-wrap`) with inner container (`.top-contact-inner`).
   - Moved contact section into this top bar and kept it as a single row (`flex-wrap: nowrap`, horizontal overflow fallback for narrow widths).
   - Logo block now starts below the contact bar.

2. **Opening hours right-aligned (title + all rows)**
   - Added right alignment to whole opening-hours section:
     - section text,
     - heading,
     - table placement,
     - each table cell.

3. **New slogan section under opening hours with image background**
   - Added `.slogan-banner` section under opening hours:
     - text: “Malé knihkupectví v malém městě, ale něco se do něj vejde.”
     - white text,
     - background image reused from existing site: `/assets/images/background-home.jpg` (with subtle dark overlay for readability).

4. **Increased logo spacing from surrounding text (horizontal + vertical)**
   - Increased logo block margins to `margin: 1.8rem 4ch 2.2rem 0;`.

### Validation
- Served locally via `python3 -m http.server 4173 --bind 0.0.0.0`.
- Captured updated full-page screenshot.
- Server logs confirm successful 200 responses for HTML and all required assets (including `background-home.jpg`).

### Preview artifact
- `browser:/tmp/codex_browser_invocations/52931322edbdaa8c/artifacts/artifacts/navrh-jednostrankovy-preview-v7.png`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b33b19de08328aff5be1321261973)